### PR TITLE
Add in-memory item API and update QR views

### DIFF
--- a/qr-test-app/src/App.vue
+++ b/qr-test-app/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app">
-    <header>
-      <h1>QR App</h1>
+    <header class="app-header">
+      <h1>QR Demo</h1>
       <nav>
         <router-link to="/generate">Generate</router-link>
         <router-link to="/scan">Scan</router-link>
@@ -14,10 +14,18 @@
 </template>
 
 <style scoped>
+header.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #f0f0f0;
+  padding: 1rem;
+}
 nav {
-  margin: 1rem 0;
+  margin: 0.5rem 0;
 }
 router-link {
   margin-right: 1rem;
+  font-weight: bold;
 }
 </style>

--- a/qr-test-app/src/components/QRCodeGenerator.vue
+++ b/qr-test-app/src/components/QRCodeGenerator.vue
@@ -1,10 +1,10 @@
 <template>
   <div>
-    <input v-model="valueToEncode" placeholder="Enter value to encode" />
-    <qrcode-vue :value="valueToEncode" :size="200" />
-    <button @click="verifyWithBackend">Verify with Backend</button>
+    <input v-model="valueToEncode" placeholder="Enter value" />
+    <qrcode-vue v-if="valueToEncode" :value="valueToEncode" :size="200" />
+    <button @click="addToBackend">Add to Backend</button>
 
-    <p v-if="verifyResult !== null">{{ verifyResult }}</p>
+    <p v-if="actionResult">{{ actionResult }}</p>
   </div>
 </template>
 
@@ -16,22 +16,40 @@ export default {
   data() {
     return {
       valueToEncode: '',
-      verifyResult: null
+      actionResult: null
     };
   },
   methods: {
-    async verifyWithBackend() {
+    async addToBackend() {
       if (!this.valueToEncode) return;
 
       try {
-        const res = await fetch(`http://localhost:5000/api/hardcoded/verify?value=${encodeURIComponent(this.valueToEncode)}`);
-        if (!res.ok) throw new Error("Not found");
-        const data = await res.json();
-        this.verifyResult = `✅ Verified: ${data.name} (ID: ${data.id}, Value: ${data.value})`;
+        const res = await fetch('http://localhost:5000/api/items', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ value: this.valueToEncode })
+        });
+        if (!res.ok) throw new Error();
+        this.actionResult = '✅ Added to backend.';
       } catch (err) {
-        this.verifyResult = "❌ Item not found in backend.";
+        this.actionResult = '❌ Failed to add value.';
       }
     }
   }
 };
 </script>
+
+<style scoped>
+div {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+input {
+  padding: 0.5rem;
+}
+button {
+  padding: 0.5rem 1rem;
+}
+</style>

--- a/qr-test-app/src/components/QRCodeScanner.vue
+++ b/qr-test-app/src/components/QRCodeScanner.vue
@@ -3,9 +3,8 @@
     <qr-scanner @decode="onDecode" />
 
     <p>Scanned: {{ scannedValue }}</p>
-    <button :disabled="!scannedValue" @click="verifyWithBackend">Verify with Backend</button>
 
-    <p v-if="verifyResult !== null">{{ verifyResult }}</p>
+    <p v-if="verifyResult">{{ verifyResult }}</p>
   </div>
 </template>
 
@@ -14,23 +13,32 @@ export default {
   data() {
     return {
       scannedValue: '',
-      verifyResult: null
+      verifyResult: ''
     };
   },
   methods: {
     onDecode(decodedText) {
       this.scannedValue = decodedText;
+      this.verifyWithBackend();
     },
     async verifyWithBackend() {
       try {
-        const res = await fetch(`http://localhost:5000/api/hardcoded/verify?value=${encodeURIComponent(this.scannedValue)}`);
-        if (!res.ok) throw new Error("Not found");
-        const data = await res.json();
-        this.verifyResult = `✅ Verified: ${data.name} (ID: ${data.id}, Value: ${data.value})`;
+        const res = await fetch(`http://localhost:5000/api/items/verify?value=${encodeURIComponent(this.scannedValue)}`);
+        if (!res.ok) throw new Error();
+        this.verifyResult = '✅ Value found in backend.';
       } catch (err) {
-        this.verifyResult = "❌ Item not found in backend.";
+        this.verifyResult = '❌ Value not found.';
       }
     }
   }
 };
 </script>
+
+<style scoped>
+div {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+}
+</style>

--- a/qr-test-backend/Controllers/ItemsController.cs
+++ b/qr-test-backend/Controllers/ItemsController.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace WebApplication1.Controllers
+{
+    [ApiController]
+    public class ItemsController : ControllerBase
+    {
+        private static readonly List<string> Items = new()
+        {
+            "demo-1",
+            "demo-2"
+        };
+
+        [HttpGet("api/items/verify")]
+        public IActionResult Verify([FromQuery] string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return BadRequest("Value is required.");
+
+            if (Items.Contains(value))
+                return Ok(new { exists = true });
+
+            return NotFound(new { exists = false });
+        }
+
+        [HttpPost("api/items")]
+        public IActionResult Add([FromBody] ItemDto dto)
+        {
+            if (dto == null || string.IsNullOrWhiteSpace(dto.Value))
+                return BadRequest("Value is required.");
+
+            Items.Add(dto.Value);
+            return Ok(new { added = true });
+        }
+
+        public class ItemDto
+        {
+            public string Value { get; set; }
+        }
+    }
+}

--- a/qr-test-backend/Program.cs
+++ b/qr-test-backend/Program.cs
@@ -2,6 +2,13 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services.AddControllersWithViews();
+builder.Services.AddCors(options =>
+{
+    options.AddDefaultPolicy(policy =>
+        policy.AllowAnyOrigin()
+              .AllowAnyHeader()
+              .AllowAnyMethod());
+});
 
 var app = builder.Build();
 
@@ -17,6 +24,8 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 
 app.UseRouting();
+
+app.UseCors();
 
 app.UseAuthorization();
 


### PR DESCRIPTION
## Summary
- create new in-memory Item API for the backend
- enable CORS in backend
- update QRCodeGenerator to add scanned values to backend and style it
- update QRCodeScanner to auto-verify scanned values against backend and style it
- tweak overall app styling

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d165433b48331aaf62d5d25ee66f0