### PR TITLE
Fix scanning init and persist items

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@
 
 ```bash
 docker-compose up --build
-
+```
 
 FE: localhost:8080
 BE: localhost:5000
+
+The backend persists scanned values in `data/items.json`. When running via
+Docker this file is mapped to the `data/` directory next to the
+`docker-compose.yml` so values survive container restarts.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,5 +21,7 @@ services:
       dockerfile: Dockerfile
     ports:
       - "5000:8080"
+    volumes:
+      - ./data:/app/data
     environment:
       - ASPNETCORE_ENVIRONMENT=Development

--- a/qr-test-app/src/components/QRCodeGenerator.vue
+++ b/qr-test-app/src/components/QRCodeGenerator.vue
@@ -30,7 +30,12 @@ export default {
           body: JSON.stringify({ value: this.valueToEncode })
         });
         if (!res.ok) throw new Error();
-        this.actionResult = '✅ Added to backend.';
+        const data = await res.json();
+        if (data.added) {
+          this.actionResult = '✅ Added to backend.';
+        } else {
+          this.actionResult = 'ℹ️ Value already exists.';
+        }
       } catch (err) {
         this.actionResult = '❌ Failed to add value.';
       }

--- a/qr-test-app/src/components/QRCodeScanner.vue
+++ b/qr-test-app/src/components/QRCodeScanner.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <qr-scanner @decode="onDecode" />
+    <qrcode-stream @decode="onDecode" @init="onInit" />
 
     <p>Scanned: {{ scannedValue }}</p>
 
@@ -9,7 +9,10 @@
 </template>
 
 <script>
+import { QrcodeStream } from 'vue-qrcode-reader';
+
 export default {
+  components: { QrcodeStream },
   data() {
     return {
       scannedValue: '',
@@ -20,6 +23,18 @@ export default {
     onDecode(decodedText) {
       this.scannedValue = decodedText;
       this.verifyWithBackend();
+    },
+    onInit(promise) {
+      promise.catch(error => {
+        console.error('Camera initialization failed', error);
+        if (error.name === 'NotAllowedError') {
+          this.verifyResult = 'Camera access was denied.';
+        } else if (error.name === 'NotFoundError') {
+          this.verifyResult = 'No camera device found.';
+        } else {
+          this.verifyResult = 'Unable to start camera.';
+        }
+      });
     },
     async verifyWithBackend() {
       try {

--- a/qr-test-backend/Controllers/ItemsController.cs
+++ b/qr-test-backend/Controllers/ItemsController.cs
@@ -1,17 +1,49 @@
 using Microsoft.AspNetCore.Mvc;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
+using System.IO;
 
 namespace WebApplication1.Controllers
 {
     [ApiController]
     public class ItemsController : ControllerBase
     {
-        private static readonly List<string> Items = new()
+        private static readonly string DataDir = Path.Combine(AppContext.BaseDirectory, "data");
+        private static readonly string ItemsFile = Path.Combine(DataDir, "items.json");
+        private static readonly HashSet<string> Items;
+
+        static ItemsController()
         {
-            "demo-1",
-            "demo-2"
-        };
+            try
+            {
+                Directory.CreateDirectory(DataDir);
+                if (System.IO.File.Exists(ItemsFile))
+                {
+                    var json = System.IO.File.ReadAllText(ItemsFile);
+                    Items = JsonSerializer.Deserialize<HashSet<string>>(json) ?? new HashSet<string>();
+                }
+                else
+                {
+                    Items = new HashSet<string>();
+                    SaveItems();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to load items: {ex.Message}");
+                Items = new HashSet<string>();
+            }
+
+            Console.WriteLine($"Items file path: {ItemsFile}");
+        }
+
+        private static void SaveItems()
+        {
+            var json = JsonSerializer.Serialize(Items, new JsonSerializerOptions { WriteIndented = true });
+            System.IO.File.WriteAllText(ItemsFile, json);
+        }
 
         [HttpGet("api/items/verify")]
         public IActionResult Verify([FromQuery] string value)
@@ -19,7 +51,13 @@ namespace WebApplication1.Controllers
             if (string.IsNullOrWhiteSpace(value))
                 return BadRequest("Value is required.");
 
-            if (Items.Contains(value))
+            bool exists;
+            lock (Items)
+            {
+                exists = Items.Contains(value);
+            }
+
+            if (exists)
                 return Ok(new { exists = true });
 
             return NotFound(new { exists = false });
@@ -31,8 +69,22 @@ namespace WebApplication1.Controllers
             if (dto == null || string.IsNullOrWhiteSpace(dto.Value))
                 return BadRequest("Value is required.");
 
-            Items.Add(dto.Value);
-            return Ok(new { added = true });
+            bool added;
+            lock (Items)
+            {
+                if (Items.Contains(dto.Value))
+                {
+                    added = false;
+                }
+                else
+                {
+                    Items.Add(dto.Value);
+                    SaveItems();
+                    added = true;
+                }
+            }
+
+            return Ok(new { added });
         }
 
         public class ItemDto


### PR DESCRIPTION
## Summary
- use `vue-qrcode-reader` with proper camera init handling
- show message if value already exists when adding
- persist items to `data/items.json` and log file path
- mount persistent data volume in Docker compose
- update README with persistence info

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d1ddc93d4833199aec676b1349e78